### PR TITLE
Navigation history

### DIFF
--- a/src/ExtendedHeuristicCompletion-History-Tests/CooNavigationHistoryTest.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Tests/CooNavigationHistoryTest.class.st
@@ -1,0 +1,112 @@
+Class {
+	#name : 'CooNavigationHistoryTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'session'
+	],
+	#category : 'ExtendedHeuristicCompletion-History-Tests-Navigation',
+	#package : 'ExtendedHeuristicCompletion-History-Tests',
+	#tag : 'Navigation'
+}
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> setUp [
+
+	super setUp.
+	session := CooSession new.
+	session noUserSelectionHandling
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testAddNavigationItemAppearsInClassEntries [
+
+	| item entries |
+	item := CooNavigationHistoryItem class: 'OrderedCollection'.
+	session addNavigationItem: item.
+
+	entries := session classEntries.
+	self assert: entries size equals: 1.
+	self assert: entries first contents equals: 'OrderedCollection'.
+	self assert: entries first sessionItem equals: item
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testAddNavigationItemAppearsInSelectorEntries [
+
+	| item entries |
+	item := CooNavigationHistoryItem selector: #at:put:.
+	session addNavigationItem: item.
+
+	entries := session selectorEntries.
+	self assert: entries size equals: 1.
+	self assert: entries first contents equals: 'at:put:'
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testClassObservationDoesNotLeakIntoSelectorEntries [
+
+	session addNavigationItem: (CooNavigationHistoryItem class: 'Array').
+
+	self assert: session selectorEntries isEmpty.
+	self assert: session classEntries size equals: 1
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testNavigationEntriesAreCappedAtFive [
+
+	1 to: 12 do: [ :i |
+		session addNavigationItem: (CooNavigationHistoryItem selector: ('selector', i asString) asSymbol) ].
+
+	self assert: session navigationSelectorEntries size equals: 5
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testNavigationEntriesAreDeduplicated [
+
+	session addNavigationItem: (CooNavigationHistoryItem selector: #foo).
+	session addNavigationItem: (CooNavigationHistoryItem selector: #foo).
+	session addNavigationItem: (CooNavigationHistoryItem selector: #bar).
+
+	self assert: session navigationSelectorEntries size equals: 2
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testNavigationItemDefaultsTimestamp [
+
+	| item |
+	item := CooNavigationHistoryItem selector: #foo.
+
+	self assert: item timestamp isNotNil.
+	self assert: item isSelectorObservation.
+	self deny: item isClassObservation
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testNavigationItemForClassReportsClassKind [
+
+	| item |
+	item := CooNavigationHistoryItem class: 'String'.
+
+	self assert: item isClassObservation.
+	self deny: item isSelectorObservation.
+	self assert: item kind equals: #class.
+	self assert: item name equals: 'String'
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testResetNavigationItemsClearsHistory [
+
+	session addNavigationItem: (CooNavigationHistoryItem class: 'Foo').
+	session resetNavigationItems.
+
+	self assert: session navigationItems isEmpty.
+	self assert: session classEntries isEmpty
+]
+
+{ #category : 'running' }
+CooNavigationHistoryTest >> testScrapperDegradesGracefullyWithoutBrowsers [
+
+	| items |
+	items := CooNavigationScrapper new snapshotItems.
+	self assert: items isCollection
+]

--- a/src/ExtendedHeuristicCompletion-History/CooNavigationHistoryItem.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooNavigationHistoryItem.class.st
@@ -1,0 +1,137 @@
+"
+I record the fact that the developer has *seen* a program element while navigating a Calypso browser.
+
+Unlike the structural history items (added/modified/removed) I'm purely an observation: the user just looked at a class, package or method without necessarily editing it.
+
+I carry:
+- `name`        the displayed name of the navigated element (a class name or a selector)
+- `kind`        either #class or #selector to know how to feed it back to the completion engine
+- `timestamp`   when the observation was captured
+- `browserTitle` (optional) the label of the originating Calypso browser
+- `paneIndex`    (optional) the pane the selection was read from
+"
+Class {
+	#name : 'CooNavigationHistoryItem',
+	#superclass : 'Object',
+	#instVars : [
+		'name',
+		'kind',
+		'timestamp',
+		'browserTitle',
+		'paneIndex'
+	],
+	#category : 'ExtendedHeuristicCompletion-History-Navigation',
+	#package : 'ExtendedHeuristicCompletion-History',
+	#tag : 'Navigation'
+}
+
+{ #category : 'instance creation' }
+CooNavigationHistoryItem class >> class: aClassName [
+
+	^ self new
+		  kind: #class;
+		  name: aClassName;
+		  yourself
+]
+
+{ #category : 'instance creation' }
+CooNavigationHistoryItem class >> selector: aSelector [
+
+	^ self new
+		  kind: #selector;
+		  name: aSelector asString;
+		  yourself
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> browserTitle [
+
+	^ browserTitle
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> browserTitle: aString [
+
+	browserTitle := aString
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> initialize [
+
+	super initialize.
+	timestamp := DateAndTime now
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> isClassObservation [
+
+	^ kind = #class
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> isSelectorObservation [
+
+	^ kind = #selector
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> kind [
+
+	^ kind
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> kind: aSymbol [
+
+	kind := aSymbol
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> name [
+
+	^ name
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> name: anObject [
+
+	name := anObject
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> paneIndex [
+
+	^ paneIndex
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> paneIndex: anObject [
+
+	paneIndex := anObject
+]
+
+{ #category : 'printing' }
+CooNavigationHistoryItem >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream space.
+	aStream nextPutAll: '('.
+	aStream nextPutAll: (kind ifNil: [ 'unknown' ] ifNotNil: [ kind asString ]).
+	aStream nextPutAll: ') '.
+	name ifNotNil: [ aStream nextPutAll: name ].
+	browserTitle ifNotNil: [
+		aStream nextPutAll: ' @ '.
+		aStream nextPutAll: browserTitle ]
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> timestamp [
+
+	^ timestamp
+]
+
+{ #category : 'accessing' }
+CooNavigationHistoryItem >> timestamp: anObject [
+
+	timestamp := anObject
+]

--- a/src/ExtendedHeuristicCompletion-History/CooNavigationScrapper.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooNavigationScrapper.class.st
@@ -1,0 +1,205 @@
+"
+I extract navigation history from open Calypso browsers and turn it into `CooNavigationHistoryItem` observations that the completion engine can consume.
+
+I mirror the live snippet:
+
+```smalltalk
+browsers := ClyBrowserMorph withAllSubclasses
+	flatCollect: [ :eachClass | eachClass allInstances ].
+```
+
+then for each browser I read its current selections and walk through `browser navigationHistory undoList` and `redoList` to recover every state the developer has visited and add a `CooNavigationHistoryItem` for each selected name.
+
+Two-way usage:
+
+- `self snapshotItems` gives a one-shot collection of items extracted from every open browser.
+- `self feedSession: aCooSession` registers each observation in the given session through `addNavigationItem:`.
+
+Because the Calypso classes are not always loaded (or available in tests), I look them up dynamically through `Smalltalk globals at: #ClyBrowserMorph ifAbsent: [ nil ]`. When they are absent I simply return an empty collection.
+"
+Class {
+	#name : 'CooNavigationScrapper',
+	#superclass : 'Object',
+	#category : 'ExtendedHeuristicCompletion-History-Navigation',
+	#package : 'ExtendedHeuristicCompletion-History',
+	#tag : 'Navigation'
+}
+
+{ #category : 'examples' }
+CooNavigationScrapper class >> feedCurrentSession [
+	"Convenience: scrape the open browsers and feed the singleton session."
+
+	<script>
+	^ self new feedSession: CooSession current
+]
+
+{ #category : 'examples' }
+CooNavigationScrapper class >> snapshotItems [
+
+	^ self new snapshotItems
+]
+
+{ #category : 'navigation' }
+CooNavigationScrapper >> browserStateOf: aHistoryEntry [
+
+	(aHistoryEntry respondsTo: #viewStates) ifTrue: [ ^ aHistoryEntry ].
+	(aHistoryEntry respondsTo: #browserState) ifTrue: [ ^ aHistoryEntry browserState ].
+	^ nil
+]
+
+{ #category : 'navigation' }
+CooNavigationScrapper >> calypsoBrowserClass [
+
+	^ Smalltalk globals at: #ClyBrowserMorph ifAbsent: [ nil ]
+]
+
+{ #category : 'actions' }
+CooNavigationScrapper >> feedSession: aCooSession [
+
+	| items |
+	items := self snapshotItems.
+	items do: [ :each | aCooSession addNavigationItem: each ].
+	^ items
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> itemsFromBrowser: aBrowser [
+
+	| browserTitle history items entries |
+	items := OrderedCollection new.
+	browserTitle := [ aBrowser window labelString ]
+		                on: Error
+		                do: [ :ex | aBrowser printString ].
+
+	"Current selections on the live browser."
+	(self readSelectionsOf: aBrowser) do: [ :pane |
+		items addAll: (self
+			itemsFromPane: pane
+			browserTitle: browserTitle
+			timestamp: DateAndTime now) ].
+
+	(aBrowser respondsTo: #navigationHistory) ifFalse: [ ^ items ].
+	history := aBrowser navigationHistory.
+	history ifNil: [ ^ items ].
+
+	entries := OrderedCollection new.
+	(history respondsTo: #undoList) ifTrue: [ entries addAll: history undoList ].
+	(history respondsTo: #redoList) ifTrue: [ entries addAll: history redoList ].
+
+	entries do: [ :entry |
+		| state |
+		state := self browserStateOf: entry.
+		state ifNotNil: [
+			(self readViewStatesOf: state) do: [ :pane |
+				items addAll: (self
+					itemsFromPane: pane
+					browserTitle: browserTitle
+					timestamp: DateAndTime now) ] ] ].
+
+	^ items
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> itemsFromPane: aPane browserTitle: aTitle timestamp: aTimestamp [
+
+	| names kind paneIndex |
+	names := aPane at: #selectedNames ifAbsent: [ #() ].
+	kind := aPane at: #kind ifAbsent: [ #selector ].
+	paneIndex := aPane at: #paneIndex ifAbsent: [ nil ].
+
+	^ names collect: [ :each |
+		  CooNavigationHistoryItem new
+			  kind: kind;
+			  name: each asString;
+			  browserTitle: aTitle;
+			  paneIndex: paneIndex;
+			  timestamp: aTimestamp;
+			  yourself ]
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> kindOfSelection: aSelection [
+
+	| items |
+	items := (aSelection respondsTo: #items)
+		         ifTrue: [ aSelection items ]
+		         ifFalse: [ #() ].
+	items isEmpty ifTrue: [ ^ #selector ].
+	(items anySatisfy: [ :item |
+		 (item class name asString includesSubstring: 'Class') or: [
+			 item class name asString includesSubstring: 'Package' ] ])
+		ifTrue: [ ^ #class ].
+	^ #selector
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> openBrowsers [
+
+	| browserClass browsers |
+	browserClass := self calypsoBrowserClass.
+	browserClass ifNil: [ ^ #() ].
+
+	browsers := browserClass withAllSubclasses flatCollect: [ :each | each allInstances ].
+	^ browsers select: [ :each |
+		  each window notNil and: [ each window isInWorld ] ]
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> readSelectionsOf: aBrowser [
+
+	| panes |
+	panes := OrderedCollection new.
+	(aBrowser respondsTo: #navigationViews) ifFalse: [ ^ panes ].
+
+	aBrowser navigationViews withIndexDo: [ :view :paneIndex |
+		| selection items names |
+		selection := view selection.
+		items := (selection respondsTo: #items)
+			         ifTrue: [ selection items ]
+			         ifFalse: [ #() ].
+		names := items collect: [ :item |
+			         [ item name ]
+				         on: Error
+				         do: [ :ex | item printString ] ].
+		panes add: ({
+			#paneIndex -> paneIndex.
+			#selectedNames -> names asArray.
+			#kind -> (self kindOfSelection: selection)
+		} asDictionary) ].
+	^ panes
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> readViewStatesOf: aBrowserState [
+
+	| panes |
+	panes := OrderedCollection new.
+	(aBrowserState respondsTo: #viewStates) ifFalse: [ ^ panes ].
+
+	aBrowserState viewStates withIndexDo: [ :viewState :paneIndex |
+		| selection items names |
+		selection := viewState selection.
+		items := (selection respondsTo: #items)
+			         ifTrue: [ selection items ]
+			         ifFalse: [ #() ].
+		names := items collect: [ :item |
+			         [ item name ]
+				         on: Error
+				         do: [ :ex | item printString ] ].
+		panes add: ({
+			#paneIndex -> paneIndex.
+			#selectedNames -> names asArray.
+			#kind -> (self kindOfSelection: selection)
+		} asDictionary) ].
+	^ panes
+]
+
+{ #category : 'private' }
+CooNavigationScrapper >> snapshotItems [
+
+	| items |
+	items := OrderedCollection new.
+	self openBrowsers do: [ :browser |
+		items addAll: (self itemsFromBrowser: browser) ].
+	^ items
+]

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -39,7 +39,8 @@ Class {
 		'userSelectionHandler',
 		'programEntityHandler',
 		'classDescriptions',
-		'methodDescriptions'
+		'methodDescriptions',
+		'navigationItems'
 	],
 	#classVars : [
 		'Current'
@@ -211,6 +212,12 @@ CooSession >> addModifiedMethodInVocabulary: anAnn [
 	self addMethodItem: item
 ]
 
+{ #category : 'navigation' }
+CooSession >> addNavigationItem: aNavigationHistoryItem [
+
+	navigationItems addFirst: aNavigationHistoryItem
+]
+
 { #category : 'class handling' }
 CooSession >> addNewClassInVocabulary: ann [
 
@@ -244,7 +251,9 @@ CooSession >> classDescriptions [
 { #category : 'matching' }
 CooSession >> classEntries [
 
-	^ userSelectionHandler sortedUserUppercasedEntries, programEntityHandler classEntries
+	^ userSelectionHandler sortedUserUppercasedEntries
+		, self navigationClassEntries
+		, programEntityHandler classEntries
 ]
 
 { #category : 'helpers' }
@@ -307,6 +316,7 @@ CooSession >> initialize [
 	super initialize.
 	self resetProgramEntities.
 	self resetInteractionItems.
+	self resetNavigationItems.
 ]
 
 { #category : 'low-level' }
@@ -327,6 +337,46 @@ CooSession >> mostRecentFrequentSelectionHandling [
 	userSelectionHandler := CooMostRecentFrequencyHandler new.
 ]
 
+{ #category : 'navigation' }
+CooSession >> navigationClassEntries [
+
+	| seen entries |
+	navigationItems ifNil: [ ^ #() ].
+	seen := Set new.
+	entries := OrderedCollection new.
+	navigationItems do: [ :item |
+		(item isClassObservation and: [ (seen includes: item name) not ]) ifTrue: [
+			seen add: item name.
+			entries add: ((CoSessionGlobalEntry contents: item name node: nil)
+					 sessionItem: item;
+					 fetcherName: 'Session Navigation';
+					 yourself) ] ].
+	^ entries first: (entries size min: 5)
+]
+
+{ #category : 'navigation' }
+CooSession >> navigationItems [
+
+	^ navigationItems
+]
+
+{ #category : 'navigation' }
+CooSession >> navigationSelectorEntries [
+
+	| seen entries |
+	navigationItems ifNil: [ ^ #() ].
+	seen := Set new.
+	entries := OrderedCollection new.
+	navigationItems do: [ :item |
+		(item isSelectorObservation and: [ (seen includes: item name) not ]) ifTrue: [
+			seen add: item name.
+			entries add: ((CoSessionSelectorEntry contents: item name node: nil)
+					 sessionItem: item;
+					 fetcherName: 'Session Navigation';
+					 yourself) ] ].
+	^ entries first: (entries size min: 5)
+]
+
 { #category : 'interaction configuration' }
 CooSession >> noUserSelectionHandling [
 
@@ -343,6 +393,7 @@ CooSession >> printOn: aStream [
 	aStream space ; nextPutAll: 'cls '; print: classDescriptions size.
 	aStream space ; nextPutAll: (userSelectionHandler class name allButFirst: 3).
 	aStream space ; nextPutAll: 'interaction'; print: completionItems size.
+	aStream space ; nextPutAll: 'navigation'; print: (navigationItems ifNil: [ 0 ] ifNotNil: [ navigationItems size ]).
 ]
 
 { #category : 'accessing - handlers' }
@@ -393,7 +444,8 @@ CooSession >> reportString [
 		aStream space ; nextPutAll: 'mths '; print: methodDescriptions size.
 		aStream space ; nextPutAll: 'cls '; print: classDescriptions size.
 		aStream space ; nextPutAll: (userSelectionHandler class name allButFirst: 3).
-		aStream space ; nextPutAll: 'interaction'; print: completionItems size ]
+		aStream space ; nextPutAll: 'interaction'; print: completionItems size .
+	aStream space ; nextPutAll: 'navigation'; print: (navigationItems ifNil: [ 0 ] ifNotNil: [ navigationItems size ]) ]
 ]
 
 { #category : 'initialization' }
@@ -402,6 +454,12 @@ CooSession >> resetInteractionItems [
 	completionItems := OrderedCollection new.
 	self mostDualRecentFrequentSelectionHandling.
 	
+]
+
+{ #category : 'printing' }
+CooSession >> resetNavigationItems [
+
+	navigationItems := OrderedCollection new
 ]
 
 { #category : 'initialization' }
@@ -413,14 +471,22 @@ CooSession >> resetProgramEntities [
 	
 ]
 
+{ #category : 'navigation' }
+CooSession >> scrapeNavigationFromOpenBrowsers [
+
+	^ CooNavigationScrapper new feedSession: self
+]
+
 { #category : 'matching' }
 CooSession >> selectorEntries [
 	"Return a list of message selector entries computed from the user interaction and the modification of program."
-	
+
 	"here I would love to know the token because I could then 
 	decide if the user is looking for a global or not."
-	
-	^ userSelectionHandler sortedUserLowercasedEntries, programEntityHandler selectorEntries 
+
+	^ userSelectionHandler sortedUserLowercasedEntries
+		, self navigationSelectorEntries
+		, programEntityHandler selectorEntries
 ]
 
 { #category : 'updating' }


### PR DESCRIPTION
Capture the program elements the developer has *seen* in open Calypso
browsers (current selections plus undo/redo navigation history) and let
them participate in the completion ranking alongside structural changes
and explicit user selections.
