### PR TITLE
Circular dependency

### DIFF
--- a/src/BaselineOfExtendedHeuristicCompletionHistory/BaselineOfExtendedHeuristicCompletionHistory.class.st
+++ b/src/BaselineOfExtendedHeuristicCompletionHistory/BaselineOfExtendedHeuristicCompletionHistory.class.st
@@ -20,27 +20,27 @@ BaselineOfExtendedHeuristicCompletionHistory class >> showHistoryPrivacySetupIfN
 
 { #category : 'baselines' }
 BaselineOfExtendedHeuristicCompletionHistory >> baseline: spec [
-
-	<baseline>
-	spec for: #common do: [ 
-		spec postLoadDoIt: #postLoad.
-		spec
-				baseline: 'ExtendedHeuristicCompletionBenchmarks'
-				with: [ spec repository: 'github://omarabedelkader/HeuristicCompletion-Benchmarks:main/src' ].
-
-		spec package: 'ExtendedHeuristicCompletion-History' ].
-		spec 
-			package: 'ExtendedHeuristicCompletion-History-Tests' 
-			with: [ spec requires: 'ExtendedHeuristicCompletion-History' ].
-		spec 
-			package: 'ExtendedHeuristicCompletion-History-Recorder' 
-			with: [ spec requires: 'ExtendedHeuristicCompletion-History' ].
-		spec 
-			package: 'ExtendedHeuristicCompletion-History-Benchmarks' 
-			with: [ spec requires: 'ExtendedHeuristicCompletion-History' ].
-		spec 
-			package: 'ExtendedHeuristicCompletion-History-Recorder-Tests' 
-			with: [ spec requires: 'ExtendedHeuristicCompletion-History-Recorder' ].
+   <baseline>
+  	spec for: #common do: [ 
+    	spec postLoadDoIt: #postLoad.
+      spec
+        	baseline: 'ExtendedHeuristicCompletionBenchmarks'
+         	with: [ spec repository: 'github://omarabedelkader/HeuristicCompletion-Benchmarks:main/src' ].
+    	spec 
+       	package: 'ExtendedHeuristicCompletion-History-Recorder'.
+     	spec 
+        	package: 'ExtendedHeuristicCompletion-History' 
+        	with: [ spec requires: 'ExtendedHeuristicCompletion-History-Recorder' ].
+     	spec 
+        	package: 'ExtendedHeuristicCompletion-History-Tests' 
+        	with: [ spec requires: 'ExtendedHeuristicCompletion-History' ].
+     	spec 
+       	package: 'ExtendedHeuristicCompletion-History-Benchmarks' 
+        	with: [ spec requires: 'ExtendedHeuristicCompletion-History' ].
+     	spec 
+       	package: 'ExtendedHeuristicCompletion-History-Recorder-Tests' 
+        	with: [ spec requires: 'ExtendedHeuristicCompletion-History-Recorder' ].
+ 	].
 ]
 
 { #category : 'baselines' }

--- a/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderTest.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderTest.class.st
@@ -30,50 +30,6 @@ CooHistoryEventRecorderTest >> setUp [
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testAddClassItem [
-    | ann item classDescriptions|
-	classDescriptions := recorder session classDescriptions.
-   ann := ClassAdded new.
-   ann classAdded: OrderedCollection.
-   recorder addClassItemOf: CooAddedClassHistoryItem
-		from: ann
-      	selectors: #(classAdded classAffected affectedClass behaviorAffected behavior).
-	
-	self assert: (recorder session classDescriptions first) nameOfClass equals: 'OrderedCollection'
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testAddClassItemWithoutClassName [
-    | ann classDescriptions|
-	classDescriptions := recorder session classDescriptions.
-    ann := ClassAdded new.
-
-    recorder addClassItemOf: CooAddedClassHistoryItem
-             from: ann
-             selectors: #().
-    self assert: (recorder session classDescriptions) equals: classDescriptions .
-]
-
-{ #category : 'running' }
-CooHistoryEventRecorderTest >> testAstOfCompiledMethodReturnsAst [
-   | method result expected|
-
-   Object compile: 'foo ^ 0'.
-   method := Object >> #foo.
-
-   result := recorder astOf: method.
-	expected := OCParser parseMethod: 'foo ^ 0'.
-
-   self assert: result equals: expected.
-    Object removeSelector: #foo.
-]
-
-{ #category : 'running' }
-CooHistoryEventRecorderTest >> testAstOfNilReturnsNil [
-    self assert: (recorder astOf: nil) isNil.
-]
-
-{ #category : 'tests' }
 CooHistoryEventRecorderTest >> testBlockValue [
     | block errBlock result |
     block := [ |str|
@@ -140,86 +96,6 @@ CooHistoryEventRecorderTest >> testDeliverNowWhenEmptyListOfEvents [
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testDeltaMessagesForNilNewAstReturnsEmpty [
-	|oldAST|
-	oldAST := OCParser parseMethod: '
-	foo 
-		^1.
-	'.
-    self assert: (recorder deltaMessagesFor: nil oldAst: oldAST) equals: #().
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testDeltaMessagesForNilOldAstReturnsAllNewMessages [
-    | newAst result |
-
-    newAst := OCParser parseMethod: 'foo
-        ^ self bar + self baz'.
-
-    result := recorder deltaMessagesFor: newAst oldAst: nil.
-
-    self assert: (result includes: #bar).
-    self assert: (result includes: #baz).
-    self assert: (result includes: #+).
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testDeltaMessagesForReturnsEmptyWhenNoNewMessages [
-    | newAst oldAst result |
-    newAst := OCParser parseMethod: '
-		foo
-        ^ self bar
-		'.
-    oldAst := OCParser parseMethod: '
-		foo
-        ^ self bar + self baz
-		'.
-		
-    result := recorder deltaMessagesFor: newAst oldAst: oldAst.
-    self assert: result isEmpty.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testDeltaMessagesForReturnsOnlyNewMessages [
-    | newAst oldAst result |
-
-    newAst := OCParser parseMethod: '
-			foo
-        		^ self bar + self baz + self another
-		'.
-
-    oldAst := OCParser parseMethod: '
-			foo
-        		^ self bar + self baz
-		'.
-		
-    result := recorder deltaMessagesFor: newAst oldAst: oldAst.
-
-    self assert: (result includes: #another).
-    self assert: (result includes: #bar) not.
-    self assert: (result includes: #baz) not.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testDeltaMessagesForWhenMethodShrinks [
-    | newAst oldAst result |
-
-	"We do difference, when the new method is shrinked, we should get an empty list of messages"
-
-	newAst := OCParser parseMethod: '
-		foo
-        ^ self bar
-	'.
-    oldAst := OCParser parseMethod: '
-		foo
-        ^ self bar + self baz + self another
-	'.
-    result := recorder deltaMessagesFor: newAst oldAst: oldAst.
-
-    self assert: result isEmpty.
-]
-
-{ #category : 'tests' }
 CooHistoryEventRecorderTest >> testEnqueueEventAddsToPendingEvents [
     | item ann event |
     recorder drainPendingEvents.
@@ -232,6 +108,23 @@ CooHistoryEventRecorderTest >> testEnqueueEventAddsToPendingEvents [
     recorder enqueueEvent: event.
     self assert: recorder pendingEvents size equals: 1.
     self assert: recorder pendingEvents last equals: event.
+]
+
+{ #category : 'tests' }
+CooHistoryEventRecorderTest >> testEnqueueEventDoesNotDeliverBeforeBatchSize [
+
+	recorder deliveryEnabled: true.
+	recorder deliveryBatchSize: 3.
+
+	recorder enqueueEvent: (Dictionary new
+			 at: #kind put: #test;
+			 yourself).
+	recorder enqueueEvent: (Dictionary new
+			 at: #kind put: #test;
+			 yourself).
+
+	self deny: recorder shouldDeliverPendingEvents.
+	self assert: recorder pendingEvents size equals: 2.
 ]
 
 { #category : 'tests' }
@@ -255,67 +148,6 @@ CooHistoryEventRecorderTest >> testEnqueueEventPreservesOrder [
     self assert: recorder pendingEvents size equals: 2.
     self assert: recorder pendingEvents first equals: event1.
     self assert: recorder pendingEvents last equals: event2.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testEnqueueEventDoesNotDeliverBeforeBatchSize [
-
-	recorder deliveryEnabled: true.
-	recorder deliveryBatchSize: 3.
-
-	recorder enqueueEvent: (Dictionary new
-			 at: #kind put: #test;
-			 yourself).
-	recorder enqueueEvent: (Dictionary new
-			 at: #kind put: #test;
-			 yourself).
-
-	self deny: recorder shouldDeliverPendingEvents.
-	self assert: recorder pendingEvents size equals: 2.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testPrepareForImageSaveClearsPendingEventsWhenSaveOnDiskIsFalse [
-
-	recorder saveOnDisk: false.
-	recorder enqueueEvent: (Dictionary new
-			 at: #kind put: #test;
-			 yourself).
-
-	recorder prepareForImageSave.
-
-	self assert: recorder pendingEvents isEmpty.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testPrepareForImageSaveKeepsPendingEventsWhenSaveOnDiskIsTrue [
-
-	recorder saveOnDisk: true.
-	recorder enqueueEvent: (Dictionary new
-			 at: #kind put: #test;
-			 yourself).
-
-	recorder prepareForImageSave.
-
-	self assert: recorder pendingEvents size equals: 1.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testShouldDeliverPendingEventsWhenBatchSizeReached [
-
-	recorder deliveryEnabled: false.
-	recorder deliveryBatchSize: 2.
-
-	recorder enqueueEvent: (Dictionary new
-			 at: #kind put: #test;
-			 yourself).
-	recorder enqueueEvent: (Dictionary new
-			 at: #kind put: #test;
-			 yourself).
-
-	recorder deliveryEnabled: true.
-
-	self assert: recorder shouldDeliverPendingEvents.
 ]
 
 { #category : 'tests' }
@@ -359,205 +191,29 @@ CooHistoryEventRecorderTest >> testIncludesInstanceOfReturnsTrueWhenPresent [
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testInstallCompletionHeuristicsAddsAtFront [
-    recorder installCompletionHeuristics.
-	
-	self assert: CoASTHeuristicsResultSetBuilder messagesHeuristic first class equals: CooSessionMessagesHeuristic.
-	self assert: CoASTHeuristicsResultSetBuilder variablesHeuristic first class equals: CooSessionVariableHeuristic.
+CooHistoryEventRecorderTest >> testPrepareForImageSaveClearsPendingEventsWhenSaveOnDiskIsFalse [
+
+	recorder saveOnDisk: false.
+	recorder enqueueEvent: (Dictionary new
+			 at: #kind put: #test;
+			 yourself).
+
+	recorder prepareForImageSave.
+
+	self assert: recorder pendingEvents isEmpty.
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testInstallCompletionHeuristicsIsIdempotent [
+CooHistoryEventRecorderTest >> testPrepareForImageSaveKeepsPendingEventsWhenSaveOnDiskIsTrue [
 
-    recorder installCompletionHeuristics.
-    recorder installCompletionHeuristics.
+	recorder saveOnDisk: true.
+	recorder enqueueEvent: (Dictionary new
+			 at: #kind put: #test;
+			 yourself).
 
-    self assert: (CoASTHeuristicsResultSetBuilder messagesHeuristic 
-        select: [ :each | each class == CooSessionMessagesHeuristic ]) size equals: 1.
-]
+	recorder prepareForImageSave.
 
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testMessageSelectorsInNilReturnsEmpty [
-    self assert: (recorder messageSelectorsIn: nil) equals: #().
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testMessageSelectorsInNoMessageSends [
-    | ast result |
-
-    ast := OCParser parseMethod: 'myMethod
-        ^ 42'.
-    result := recorder messageSelectorsIn: ast.
-    self assert: result isEmpty.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testMessageSelectorsInReturnsSelectorsFromAst [
-    | ast result |
-    ast := OCParser parseMethod: 
-        'foo 
-            | x |
-            x := self bar.
-            x := x baz + x bar.
-            ^ x printString
-        '.
-    result := recorder messageSelectorsIn: ast.
-
-    self assert: result isNotEmpty.
-    self assert: (result includes: #bar).
-    self assert: (result includes: #baz).
-    self assert: (result includes: #+).
-    self assert: (result includes: #printString).
-	"foo is a method node"
-    self assert: (result includes: #foo) not.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testMethodFromReturnsCompiledMethod [
-    | ann result |
-
-    ann := MethodAdded new.
-    ann method: (Object >> #printString).
-
-    result := recorder methodFrom: ann.
-
-    self assert: result notNil.
-    self assert: result selector equals: #printString.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testMethodFromReturnsNilWhenNoValidMethod [
-    | ann result |
-
-    ann := MethodAdded new.
-
-    result := recorder methodFrom: ann.
-    self assert: result isNil.
-]
-
-{ #category : 'running' }
-CooHistoryEventRecorderTest >> testMethodItemFrom [
-	| ann |
-	ann := MethodAdded new. 
-	ann method: (Object >> #printString).
-
-	recorder addMethodItemOf: CooModifiedMethodHistoryItem from: ann oldMethod: (Object >> #printString).
-	
-	self assert: (recorder session methodDescriptions) first selector equals: 'printString'
-]
-
-{ #category : 'running' }
-CooHistoryEventRecorderTest >> testMethodItemFromNil [ 
-	
-	|methodDescription|
-	methodDescription := recorder session methodDescriptions.
-	self assert: (recorder addMethodItemOf: CooAddedClassHistoryItem new from: nil oldMethod: nil) equals: recorder .
-	self assert: (recorder session methodDescriptions) equals: methodDescription
-]
-
-{ #category : 'running' }
-CooHistoryEventRecorderTest >> testMethodItemFromWithoutSelector [
-	| ann methodDescription |
-	
-	methodDescription := recorder session methodDescriptions.
-	ann := MethodAdded new. 
-	ann method: CompiledMethod new.
-	
-	self assert: (recorder addMethodItemOf: CooModifiedMethodHistoryItem from: ann oldMethod: nil) equals: recorder.
-	self assert: (recorder session methodDescriptions) equals: methodDescription
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testNormalizedClassNameFromNilReturnsNil [
-    self assert: (recorder normalizedClassNameFrom: nil) isNil.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testNormalizedClassNameFromObjectWithName [
-    self assert: (recorder normalizedClassNameFrom: OrderedCollection) equals: 'OrderedCollection'.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testNormalizedClassNameFromObsoleteClass [
-    "strips the AnObsolete prefix"
-    | mock |
-    mock := CoMockClass new.
-    mock name: 'AnObsoleteMyClass'.
-    self assert: (recorder normalizedClassNameFrom: mock) equals: 'MyClass'.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testOldMethodFromReturnsCompiledMethod [
-
-    | ann result compiledMethod |
-
-    compiledMethod := Object >> #printString.
-    ann := MethodModified new.
-    ann oldMethod: compiledMethod.
-    result := recorder oldMethodFrom: ann.
-    self assert: result notNil.
-    self assert: result selector equals: #printString.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testOldMethodFromWithNonCompatibleAnnouncement [
-
-    | ann result compiledMethod |
-	"We just useed another subclass of MethodAnnouncement, wee could also try with nil or any other class"
-    compiledMethod := Object >> #printString.
-    ann := MethodAdded new.
-    ann method: compiledMethod.
-
-    result := recorder oldMethodFrom: ann.
-    self assert: result isNil.
-
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testRecordClassItem [
-    | item ann |
-    recorder drainPendingEvents.
-    self assert: recorder pendingEvents isEmpty.
-
-    ann := ClassAdded new.
-    item := CooAddedClassHistoryItem new
-        nameOfClass: 'MyClass';
-        timestamp: DateAndTime now;
-        yourself.
-
-    recorder recordClassItem: item announcement: ann.
-
-    self assert: recorder session classDescriptions first equals: item.
-
-    self assert: recorder pendingEvents size equals: 1.
-    self assert: (recorder pendingEvents first at: #kind) equals: #class.
-    self assert: (recorder pendingEvents first at: #className) equals: 'MyClass'.
-    self assert: (recorder pendingEvents first at: #announcementClass) equals: ann class name.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testRecordMethodItem [
-    | item ann |
-    recorder drainPendingEvents.
-    self assert: recorder pendingEvents isEmpty.
-
-    ann := MethodAdded new.
-    item := CooAddedMethodHistoryItem new
-        nameOfClass: 'MyClass';
-        selector: #myMethod;
-        timestamp: DateAndTime now;
-        deltaMessages: #();
-        yourself.
-
-    recorder recordMethodItem: item announcement: ann.
-
-    self assert: recorder session methodDescriptions first equals: item.
-
-    self assert: recorder pendingEvents size equals: 1.
-    self assert: (recorder pendingEvents first at: #kind) equals: #method.
-    self assert: (recorder pendingEvents first at: #className) equals: 'MyClass'.
-    self assert: (recorder pendingEvents first at: #selector) equals: #myMethod asString.
-    self assert: (recorder pendingEvents first at: #announcementClass) equals: ann class name.
+	self assert: recorder pendingEvents size equals: 1.
 ]
 
 { #category : 'tests' }
@@ -636,34 +292,6 @@ CooHistoryEventRecorderTest >> testRequeueEventsPreservesOrder [
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testSelectorOf [
-	self assert: (recorder selectorOf: (Object >> #printString)) equals: #printString
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testSelectorOfAnnouncementWhenMethodIsNil [
-	|announcement|
-	announcement := MethodAdded new method: (Object >> #printString).
-	self assert: (recorder selectorOf: nil announcement: announcement) equals: #printString
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testSelectorOfAnnouncementWhenMethodResponds [
-	self assert: (recorder selectorOf: (Object >> #printString) announcement: nil) equals: #printString
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testSelectorOfAnnouncementWhenNoResponse [
-	"We send a random object and a random announcement"
-	self assert: (recorder selectorOf: Object new announcement: MethodAdded new) equals: nil
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testSelectorOfWhenMethodIsNil [
-	self assert: (recorder selectorOf: nil) equals: nil
-]
-
-{ #category : 'tests' }
 CooHistoryEventRecorderTest >> testSerializePayload [
 	| payload result expectedString |
 
@@ -676,40 +304,19 @@ CooHistoryEventRecorderTest >> testSerializePayload [
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testSubscribeAnnouncementNamedSend [
+CooHistoryEventRecorderTest >> testShouldDeliverPendingEventsWhenBatchSizeReached [
 
-	recorder subscribeAnnouncementNamed: #ClassRemoved send: #classRemoved:.
-	
-	self assert: (recorder announcer numberOfSubscriptions ) equals: initialSubscriptionNumber + 1.
-]
+	recorder deliveryEnabled: false.
+	recorder deliveryBatchSize: 2.
 
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testSubscribeAnnouncementNamedSendWhenNotAnnouncementClass [
-    | result |
-    result := recorder subscribeAnnouncementNamed: #OrderedCollection send: #classAdded:.
-    self assert: result equals: recorder.
-    self assert: recorder announcer numberOfSubscriptions equals: initialSubscriptionNumber.
-]
+	recorder enqueueEvent: (Dictionary new
+			 at: #kind put: #test;
+			 yourself).
+	recorder enqueueEvent: (Dictionary new
+			 at: #kind put: #test;
+			 yourself).
 
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testValueFromSelector [
-    self assert: (recorder valueFrom: -1  selector: #abs) equals: 1
-]
+	recorder deliveryEnabled: true.
 
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testValueFromSelectorWhenException [
-
-    self assert: (recorder valueFrom: '1' selector: #abs) equals: nil
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testValueFromSelectorWhenObjectIsNil [
-	
-	self assert: (recorder valueFrom: (nil) selector: #increment) equals: nil
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testValueFromSelectorWhenUnknownSelector [
-	self assert: (recorder valueFrom: 1 selector: #unknownSelector) equals: nil
-	
+	self assert: recorder shouldDeliverPendingEvents.
 ]

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -717,6 +717,22 @@ CooHistoryEventRecorder >> dictionaryForCompletionAnnouncement: anAnnouncement [
 ]
 
 { #category : 'serializing' }
+CooHistoryEventRecorder >> dictionaryForCompletionItem: anItem announcement: anAnn [
+
+    | dictionary |
+
+    dictionary := Dictionary new.
+    dictionary at: #kind put: #completion.
+    dictionary at: #timestamp put: DateAndTime now asString.
+    dictionary at: #announcementClass put: anAnn class name.
+    dictionary at: #token put: (self safeValue: [ anItem token asString ] ifError: [ nil ]).
+    dictionary at: #index put: (self safeValue: [ anItem index ] ifError: [ nil ]).
+    dictionary at: #selectedItem put: (self safeValue: [ anItem selectedItem asString ] ifError: [ nil ]).
+    dictionary at: #fetchers put: (self safeValue: [ anItem fetchers ] ifError: [ #() ]).
+    ^ dictionary
+]
+
+{ #category : 'serializing' }
 CooHistoryEventRecorder >> dictionaryForMethodItem: item announcement: anAnnouncement [
 
 	| dictionary |

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -838,7 +838,7 @@ CooHistoryEventRecorder >> install [
 
 	announcer := self class codeChangeAnnouncer.
 	
-	announcer when: IcePushed send: #addNewMethodInVocabulary: to: self class uniqueInstance.
+	announcer when: IcePushed send: #onIcePushed: to: self class uniqueInstance.
 	
 
 	installed := true.

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -844,8 +844,6 @@ CooHistoryEventRecorder >> install [
 
 	announcer := self class codeChangeAnnouncer.
 	
-	self subscribeCodeChangeAnnouncements.
-	self installCompletionHeuristics.
 
 	installed := true.
 	self log: 'CooHistoryEventRecorder installed. Server: ', self serverUrl asString.

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -438,53 +438,6 @@ CooHistoryEventRecorder class >> uniqueInstance [
 	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
-{ #category : 'events-class' }
-CooHistoryEventRecorder >> addClassItemOf: aHistoryItemClass from: anAnnouncement selectors: selectorSymbols [
-
-	| className item |
-	className := self classNameFrom: anAnnouncement selectors: selectorSymbols.
-	className ifNil: [ ^ self ].
-
-	item := aHistoryItemClass new
-		        nameOfClass: className;
-		        live: true;
-		        timestamp: DateAndTime now;
-		        yourself.
-
-	self recordClassItem: item announcement: anAnnouncement
-]
-
-{ #category : 'events-class' }
-CooHistoryEventRecorder >> addMethodItemOf: aHistoryItemClass from: anAnnouncement oldMethod: oldCompiledMethod [
-
-	| method selector className ast oldAst deltaMessages item |
-	method := self methodFrom: anAnnouncement.
-	method ifNil: [ ^ self ].
-
-
-	selector := self selectorOf: method announcement: anAnnouncement.
-	selector ifNil: [ ^ self ].
-
-	className := self classNameFromMethod: method announcement: anAnnouncement.
-	className ifNil: [ ^ self ].
-
-	ast := self astOf: method.
-	oldAst := self astOf: oldCompiledMethod.
-	deltaMessages := self deltaMessagesFor: ast oldAst: oldAst.
-
-	item := aHistoryItemClass new
-		        selector: selector;
-		        nameOfClass: className;
-		        live: true;
-		        timestamp: DateAndTime now;
-		        yourself.
-
-	ast ifNotNil: [ item ast: ast ].
-	deltaMessages ifNotEmpty: [ item deltaMessages: deltaMessages ].
-
-	self recordMethodItem: item announcement: anAnnouncement
-]
-
 { #category : 'actions' }
 CooHistoryEventRecorder >> announcer [
 	^ announcer
@@ -493,22 +446,6 @@ CooHistoryEventRecorder >> announcer [
 { #category : 'actions' }
 CooHistoryEventRecorder >> announcer: anAnnouncer [ 
 	announcer := anAnnouncer.
-]
-
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> astOf: aCompiledMethod [
-
-	aCompiledMethod ifNil: [ ^ nil ].
-
-	^ [ aCompiledMethod ast ]
-		  on: Error
-		  do: [ :ex |
-			  [ aCompiledMethod sourceNode ]
-				  on: Error
-				  do: [ :ex2 |
-					  [ OCParser parseMethod: aCompiledMethod sourceCode ]
-						  on: Error
-						  do: [ :ex3 | nil ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -523,78 +460,11 @@ CooHistoryEventRecorder >> category: aSymbolOrString [
 	category := aSymbolOrString
 ]
 
-{ #category : 'events-class' }
-CooHistoryEventRecorder >> classAdded: anAnnouncement [
-
-	self
-		addClassItemOf: CooAddedClassHistoryItem
-		from: anAnnouncement
-		selectors: #(classAdded classAffected affectedClass behaviorAffected behavior)
-
-]
-
-{ #category : 'events-class' }
-CooHistoryEventRecorder >> classModified: anAnnouncement [
-
-	(self class environment includesKey: #CooModifiedClassHistoryItem)
-		ifFalse: [ ^ self ].
-
-	self
-		addClassItemOf: CooModifiedClassHistoryItem
-		from: anAnnouncement
-		selectors: #(classModified classAffected affectedClass behaviorAffected behavior)
-
-]
-
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> classNameFrom: anAnnouncement selectors: selectorSymbols [
-
-	selectorSymbols do: [ :eachSelector |
-		| value |
-		value := self valueFrom: anAnnouncement selector: eachSelector.
-		value ifNotNil: [ ^ self normalizedClassNameFrom: value ] ].
-
-	^ nil
-]
-
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> classNameFromMethod: aCompiledMethod announcement: anAnnouncement [
-
-	| methodClass |
-	methodClass := self valueFrom: aCompiledMethod selector: #methodClass.
-	methodClass ifNotNil: [ ^ self normalizedClassNameFrom: methodClass ].
-
-	^ self
-		  classNameFrom: anAnnouncement
-		  selectors: #(methodClass classAffected affectedClass behaviorAffected behavior classRemoved classAdded)
-]
-
-{ #category : 'events-class' }
-CooHistoryEventRecorder >> classRemoved: anAnnouncement [
-
-	self
-		addClassItemOf: CooRemovedClassHistoryItem
-		from: anAnnouncement
-		selectors: #(classRemoved classAffected affectedClass behaviorAffected behavior)
-]
-
 { #category : 'actions' }
 CooHistoryEventRecorder >> clearPendingEvents [
 
 	deliveryMutex critical: [ pendingEvents removeAll ].
 	^ self
-]
-
-{ #category : 'events-completion' }
-CooHistoryEventRecorder >> completionItemSelected: anAnnouncement [
-
-	"Keep the history-side completion interaction if the announcement has the shape CooSession expects."
-
-	[ self session addCompletionItem: anAnnouncement ]
-		on: Error
-		do: [ :ex | "Do not break completion if the announcement shape changed." ].
-
-	self enqueueEvent: (self dictionaryForCompletionAnnouncement: anAnnouncement)
 ]
 
 { #category : 'installation' }
@@ -672,19 +542,6 @@ CooHistoryEventRecorder >> deliveryEnabled: aBoolean [
 { #category : 'events-class' }
 CooHistoryEventRecorder >> deliveryProcess [ 
 	^ deliveryProcess
-]
-
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> deltaMessagesFor: newAst oldAst: oldAst [
-
-	| newMessages oldMessages |
-	newAst ifNil: [ ^ #() ].
-
-	newMessages := self messageSelectorsIn: newAst.
-	oldAst ifNil: [ ^ newMessages ].
-
-	oldMessages := self messageSelectorsIn: oldAst.
-	^ newMessages difference: oldMessages
 ]
 
 { #category : 'serializing' }
@@ -845,27 +702,6 @@ CooHistoryEventRecorder >> install [
 	^ self
 ]
 
-{ #category : 'installation' }
-CooHistoryEventRecorder >> installCompletionHeuristics [
-
-	| builder |
-	builder := self class environment
-		           at: #CoASTHeuristicsResultSetBuilder
-		           ifAbsent: [ ^ self ].
-
-	((builder respondsTo: #messagesHeuristic)
-		and: [ self includesInstanceOf: CooSessionMessagesHeuristic in: builder messagesHeuristic ])
-		ifFalse: [
-			(builder respondsTo: #messagesHeuristic)
-				ifTrue: [ builder messagesHeuristic addFirst: CooSessionMessagesHeuristic new ] ].
-
-	((builder respondsTo: #variablesHeuristic)
-		and: [ self includesInstanceOf: CooSessionVariableHeuristic in: builder variablesHeuristic ])
-		ifFalse: [
-			(builder respondsTo: #variablesHeuristic)
-				ifTrue: [ builder variablesHeuristic addFirst: CooSessionVariableHeuristic new ] ]
-]
-
 { #category : 'accessing' }
 CooHistoryEventRecorder >> installed [
 
@@ -905,59 +741,6 @@ CooHistoryEventRecorder >> logToTranscript: aBoolean [
 	logToTranscript := aBoolean
 ]
 
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> messageSelectorsIn: anAst [
-
-	anAst ifNil: [ ^ #() ].
-
-	^ [
-		  (anAst allChildren
-			   select: [ :each |
-				   (each respondsTo: #isMessage) and: [ each isMessage ] ])
-			   collect: [ :each | each selector ] ]
-		  on: Error
-		  do: [ :ex | #() ]
-]
-
-{ #category : 'events-methods' }
-CooHistoryEventRecorder >> methodAdded: anAnnouncement [
-
-	self
-		addMethodItemOf: CooAddedMethodHistoryItem
-		from: anAnnouncement
-		oldMethod: nil
-]
-
-{ #category : 'events-methods' }
-CooHistoryEventRecorder >> methodFrom: anAnnouncement [
-
-	#(method newMethod compiledMethod) do: [ :eachSelector |
-		| value |
-		value := self valueFrom: anAnnouncement selector: eachSelector.
-		(value notNil and: [ value respondsTo: #selector ])
-			ifTrue: [ ^ value ] ].
-
-	^ nil
-]
-
-{ #category : 'events-methods' }
-CooHistoryEventRecorder >> methodModified: anAnnouncement [
-
-	self
-		addMethodItemOf: CooModifiedMethodHistoryItem
-		from: anAnnouncement
-		oldMethod: (self oldMethodFrom: anAnnouncement)
-]
-
-{ #category : 'events-methods' }
-CooHistoryEventRecorder >> methodRemoved: anAnnouncement [
-
-	self
-		addMethodItemOf: CooRemovedMethodHistoryItem
-		from: anAnnouncement
-		oldMethod: nil
-]
-
 { #category : 'actions' }
 CooHistoryEventRecorder >> multipartEntityForBytes: aByteArray category: aCategory [
 
@@ -969,36 +752,6 @@ CooHistoryEventRecorder >> multipartEntityForBytes: aByteArray category: aCatego
 		addPart: (ZnMimePart fieldName: 'data' entity: (ZnByteArrayEntity bytes: aByteArray)).
 
 	^ entity
-]
-
-{ #category : 'actions' }
-CooHistoryEventRecorder >> normalizedClassNameFrom: anObject [
-
-	| name |
-	anObject ifNil: [ ^ nil ].
-
-	name := (anObject respondsTo: #name)
-		        ifTrue: [ anObject name ]
-		        ifFalse: [ anObject asString ].
-
-	name := name asString.
-
-	(name beginsWith: 'AnObsolete')
-		ifTrue: [ name := name allButFirst: 'AnObsolete' size ].
-
-	^ name
-]
-
-{ #category : 'events-methods' }
-CooHistoryEventRecorder >> oldMethodFrom: anAnnouncement [
-
-	#(oldMethod previousMethod oldCompiledMethod) do: [ :eachSelector |
-		| value |
-		value := self valueFrom: anAnnouncement selector: eachSelector.
-		(value notNil and: [ value respondsTo: #selector ])
-			ifTrue: [ ^ value ] ].
-
-	^ nil
 ]
 
 { #category : 'actions' }
@@ -1062,21 +815,6 @@ CooHistoryEventRecorder >> putBytes: aByteArray category: aCategory [
 ]
 
 { #category : 'actions' }
-CooHistoryEventRecorder >> recordClassItem: item announcement: anAnnouncement [
-
-	self session addClassItem: item.
-	self enqueueEvent: (self dictionaryForClassItem: item announcement: anAnnouncement)
-]
-
-{ #category : 'actions' }
-CooHistoryEventRecorder >> recordMethodItem: item announcement: anAnnouncement [
-
-	self session addMethodItem: item.
-	self enqueueEvent: (self dictionaryForMethodItem: item announcement: anAnnouncement)
-
-]
-
-{ #category : 'actions' }
 CooHistoryEventRecorder >> requeueEvents: events [
 
 	deliveryMutex critical: [
@@ -1102,27 +840,6 @@ CooHistoryEventRecorder >> saveOnDisk [
 CooHistoryEventRecorder >> saveOnDisk: aBoolean [
 
 	saveOnDisk := aBoolean
-]
-
-{ #category : 'events-methods' }
-CooHistoryEventRecorder >> selectorOf: aCompiledMethod [
-
-	^ self valueFrom: aCompiledMethod selector: #selector
-]
-
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> selectorOf: aCompiledMethod announcement: anAnnouncement [
-
-	| selector |
-	selector := self valueFrom: aCompiledMethod selector: #selector.
-	selector ifNotNil: [ ^ selector ].
-
-	#(selector methodSelector) do: [ :eachSelector |
-		| value |
-		value := self valueFrom: anAnnouncement selector: eachSelector.
-		value ifNotNil: [ ^ value ] ].
-
-	^ nil
 ]
 
 { #category : 'actions' }
@@ -1158,49 +875,6 @@ CooHistoryEventRecorder >> shouldDeliverPendingEvents [
 
 	^ self deliveryEnabled and: [
 		  pendingEvents size >= self deliveryBatchSize ]
-]
-
-{ #category : 'installation' }
-CooHistoryEventRecorder >> subscribeAnnouncementNamed: announcementName send: selector [
-
-	| announcementClass |
-	announcementClass := self class environment
-		                     at: announcementName
-		                     ifAbsent: [ ^ self ].
-	
-	"When the passed class does not inherit from Announcement, we do nothing"
-	(announcementClass inheritsFrom: Announcement)
-        ifFalse: [ ^ self ].
-
-	announcer
-		when: announcementClass
-		send: selector
-		to: self.
-]
-
-{ #category : 'installation' }
-CooHistoryEventRecorder >> subscribeCodeChangeAnnouncements [
-
-	self subscribeAnnouncementNamed: #MethodAdded send: #methodAdded:.
-	self subscribeAnnouncementNamed: #MethodModified send: #methodModified:.
-	self subscribeAnnouncementNamed: #MethodRemoved send: #methodRemoved:.
-
-	self subscribeAnnouncementNamed: #ClassAdded send: #classAdded:.
-	self subscribeAnnouncementNamed: #ClassModified send: #classModified:.
-	self subscribeAnnouncementNamed: #ClassRemoved send: #classRemoved:.
-
-	self subscribeAnnouncementNamed: #CoCompletionItemSelected send: #completionItemSelected:
-]
-
-{ #category : 'helpers' }
-CooHistoryEventRecorder >> valueFrom: anObject selector: selector [
-
-	anObject ifNil: [ ^ nil ].
-	(anObject respondsTo: selector) ifFalse: [ ^ nil ].
-
-	^ [ anObject perform: selector ]
-		  on: Error
-		  do: [ :ex | nil ]
 ]
 
 { #category : 'actions' }

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -800,6 +800,13 @@ CooHistoryEventRecorder >> envelopeFor: eventDictionaries [
 ]
 
 { #category : 'actions' }
+CooHistoryEventRecorder >> flush [
+
+    pendingEvents isEmpty ifTrue: [ ^ self ].
+    self deliverNowInBackground.
+]
+
+{ #category : 'actions' }
 CooHistoryEventRecorder >> imageInfo [
 
 	| info |
@@ -843,6 +850,8 @@ CooHistoryEventRecorder >> install [
 	self class registerForImageLifecycle.
 
 	announcer := self class codeChangeAnnouncer.
+	
+	announcer when: IcePushed send: #addNewMethodInVocabulary: to: self class uniqueInstance.
 	
 
 	installed := true.
@@ -1005,6 +1014,12 @@ CooHistoryEventRecorder >> oldMethodFrom: anAnnouncement [
 			ifTrue: [ ^ value ] ].
 
 	^ nil
+]
+
+{ #category : 'actions' }
+CooHistoryEventRecorder >> onIcePushed: anIcePushedAnnouncement [
+
+    self flush.
 ]
 
 { #category : 'accessing' }

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -198,7 +198,6 @@ Class {
 	#name : 'CooHistoryEventRecorder',
 	#superclass : 'Object',
 	#instVars : [
-		'session',
 		'announcer',
 		'installed',
 		'serverUrl',
@@ -818,8 +817,6 @@ CooHistoryEventRecorder >> includesInstanceOf: aClass in: aCollection [
 CooHistoryEventRecorder >> initialize [
 
 	super initialize.
-	session := CooSession current.
-	session recorder: self.
 	serverUrl := self class defaultServerUrl.
 	category := self class defaultCategory.
 	deliveryEnabled := true.
@@ -1154,18 +1151,6 @@ CooHistoryEventRecorder >> serverUrl [
 CooHistoryEventRecorder >> serverUrl: aStringOrZnUrl [
 
 	serverUrl := aStringOrZnUrl asZnUrl
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder >> session [
-
-	^ session ifNil: [ session := CooSession current ]
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder >> session: aCooSession [
-
-	session := aCooSession
 ]
 
 { #category : 'actions' }

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -819,6 +819,7 @@ CooHistoryEventRecorder >> initialize [
 
 	super initialize.
 	session := CooSession current.
+	session recorder: self.
 	serverUrl := self class defaultServerUrl.
 	category := self class defaultCategory.
 	deliveryEnabled := true.

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -703,33 +703,20 @@ CooHistoryEventRecorder >> dictionaryForClassItem: item announcement: anAnnounce
 ]
 
 { #category : 'serializing' }
-CooHistoryEventRecorder >> dictionaryForCompletionAnnouncement: anAnnouncement [
+CooHistoryEventRecorder >> dictionaryForCompletionItem: anItem [
 
 	| dictionary |
-	dictionary := Dictionary new.
-	dictionary at: #kind put: #completion.
-	dictionary at: #timestamp put: DateAndTime now asString.
-	dictionary at: #announcementClass put: anAnnouncement class name.
-	dictionary at: #token put: (self safeValue: [ anAnnouncement token asString ] ifError: [ nil ]).
-	dictionary at: #index put: (self safeValue: [ anAnnouncement index ] ifError: [ nil ]).
-	dictionary at: #selectedItem put: (self safeValue: [ anAnnouncement selectedItem asString ] ifError: [ nil ]).
-	^ dictionary
-]
 
-{ #category : 'serializing' }
-CooHistoryEventRecorder >> dictionaryForCompletionItem: anItem announcement: anAnn [
+   dictionary := Dictionary new.
+   dictionary at: #kind put: #completion.
+   dictionary at: #timestamp put: DateAndTime now asString.
 
-    | dictionary |
-
-    dictionary := Dictionary new.
-    dictionary at: #kind put: #completion.
-    dictionary at: #timestamp put: DateAndTime now asString.
-    dictionary at: #announcementClass put: anAnn class name.
-    dictionary at: #token put: (self safeValue: [ anItem token asString ] ifError: [ nil ]).
-    dictionary at: #index put: (self safeValue: [ anItem index ] ifError: [ nil ]).
-    dictionary at: #selectedItem put: (self safeValue: [ anItem selectedItem asString ] ifError: [ nil ]).
-    dictionary at: #fetchers put: (self safeValue: [ anItem fetchers ] ifError: [ #() ]).
-    ^ dictionary
+   dictionary at: #token put: (self safeValue: [ anItem token asString ] ifError: [ nil ]).
+   dictionary at: #index put: (self safeValue: [ anItem index ] ifError: [ nil ]).
+   dictionary at: #selectedItem put: (self safeValue: [ anItem selectedItem asString ] ifError: [ nil ]).
+	dictionary at: #fetchers put: (self safeValue: [ anItem fetchers ] ifError: [ #() ]).
+	dictionary at: #choices put: (self safeValue: anItem choices  ifError: [ #() ]).
+   ^ dictionary
 ]
 
 { #category : 'serializing' }

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -40,7 +40,8 @@ Class {
 		'programEntityHandler',
 		'classDescriptions',
 		'methodDescriptions',
-		'navigationItems'
+		'navigationItems',
+		'recorder'
 	],
 	#classVars : [
 		'Current'

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -433,6 +433,11 @@ CooSession >> recorder [
 	^ recorder ifNil: [ recorder := CooHistoryEventRecorder uniqueInstance ]
 ]
 
+{ #category : 'matching' }
+CooSession >> recorder: aRecorder [
+	recorder := aRecorder 
+]
+
 { #category : 'class handling' }
 CooSession >> removeClassFromVocabulary: ann [
 

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -430,7 +430,7 @@ CooSession >> programEntityHandler: aCache [
 
 { #category : 'matching' }
 CooSession >> recorder [ 
-	^ recorder  ifNil: [CooHistoryEventRecorder uniqueInstance]
+	^ recorder ifNil: [ recorder := CooHistoryEventRecorder uniqueInstance ]
 ]
 
 { #category : 'class handling' }

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -189,7 +189,7 @@ CooSession >> addCompletionItem: aCompletionEntryItem [
 	userSelectionHandler handleNewSelectionItem: item. 
 	
 	"pass the selected item to the recorder"
-	self recorder enqueueEvent: (self recorder dictionaryForCompletionItem: item announcement: CoCompletionItemSelected).
+	self recorder enqueueEvent: (self recorder dictionaryForCompletionItem: item).
 ]
 
 { #category : 'method handling' }

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -409,6 +409,11 @@ CooSession >> programEntityHandler: aCache [
 	programEntityHandler := aCache
 ]
 
+{ #category : 'matching' }
+CooSession >> recorder [ 
+	^ recorder  ifNil: [CooHistoryEventRecorder uniqueInstance]
+]
+
 { #category : 'class handling' }
 CooSession >> removeClassFromVocabulary: ann [
 

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -184,7 +184,10 @@ CooSession >> addCompletionItem: aCompletionEntryItem [
 	
 	"Instead of poking the handler during each addition we could pass it all the info when 
 	requesting a list of entries."
-	userSelectionHandler handleNewSelectionItem: item
+	userSelectionHandler handleNewSelectionItem: item. 
+	
+	"pass the selected item to the recorder"
+	self recorder enqueueEvent: (self recorder dictionaryForClassItem: item announcement: CoCompletionItemSelected).
 ]
 
 { #category : 'method handling' }
@@ -210,7 +213,9 @@ CooSession >> addModifiedMethodInVocabulary: anAnn [
 		        yourself.
 	deltaMessage ifNotEmpty: [ item deltaMessages: deltaMessage ].
 	
-	self addMethodItem: item
+	self addMethodItem: item.
+	
+	self recorder enqueueEvent: (self recorder dictionaryForClassItem: item announcement: anAnn).
 ]
 
 { #category : 'navigation' }
@@ -222,25 +227,37 @@ CooSession >> addNavigationItem: aNavigationHistoryItem [
 { #category : 'class handling' }
 CooSession >> addNewClassInVocabulary: ann [
 
-	self addClassItem: (CooAddedClassHistoryItem new
+	|historyItem|
+
+	historyItem := CooAddedClassHistoryItem new
 			 nameOfClass: ann classAdded name;
 			live: true;
 			 "meta: anAnn classAdded check if we get the classAdded for metaclass"
 			timestamp: DateAndTime now;
-			yourself) "we could also decide that when a class gets a new method the name of the class is getting more important. 
+			yourself.
+
+	self addClassItem: historyItem.  "we could also decide that when a class gets a new method the name of the class is getting more important. 
 	Focus of attention. So this can be computed latter based on such information. "
+	
+	self recorder enqueueEvent: (self recorder dictionaryForClassItem: historyItem announcement: ann)
 ]
 
 { #category : 'method handling' }
 CooSession >> addNewMethodInVocabulary: anAnn [
 
-	self addMethodItem: (CooAddedMethodHistoryItem new
+	|historyItem|
+
+	historyItem := CooAddedMethodHistoryItem new
 			 selector: anAnn method selector;
 			 live: true;
 			 timestamp: DateAndTime now;
 			 nameOfClass: anAnn method methodClass name;
-			 yourself) "we could also decide that when a class gets a new method the name of the class is getting more important. 
+			 yourself.
+
+	self addMethodItem: historyItem. "we could also decide that when a class gets a new method the name of the class is getting more important. 
 	Focus of attention. So this can be computed latter based on such information. "
+
+	self recorder enqueueEvent: (self recorder dictionaryForClassItem: historyItem announcement: anAnn )
 ]
 
 { #category : 'low-level' }
@@ -417,28 +434,38 @@ CooSession >> recorder [
 { #category : 'class handling' }
 CooSession >> removeClassFromVocabulary: ann [
 
-	| removedClassName |
+	| removedClassName historyItem|
 	removedClassName := ann classRemoved name.
 	(removedClassName beginsWith: 'AnObsolete')
 		ifTrue: [ removedClassName := removedClassName allButFirst: 'AnObsolete' size ].
-		
-	self addClassItem: (CooRemovedClassHistoryItem new
+
+	historyItem := CooRemovedClassHistoryItem new
 			nameOfClass: removedClassName;
 			 "meta: anAnn classAdded check if we get the classAdded for metaclass"
 			live: true;
 			timestamp: DateAndTime now;
-			yourself)
+			yourself.
+
+	self addClassItem: historyItem.
+
+	self recorder enqueueEvent: (self recorder dictionaryForClassItem: historyItem announcement: ann)
 ]
 
 { #category : 'method handling' }
 CooSession >> removeMethodFromVocabulary: anAnn [
 
-	self addMethodItem: (CooRemovedMethodHistoryItem new
+	|historyItem|
+
+	historyItem := CooRemovedMethodHistoryItem new
 			 selector: anAnn method selector;
 			 live: true;
 			 timestamp: DateAndTime now;
 			 nameOfClass: anAnn method methodClass name;
-			 yourself) 
+			 yourself.
+
+	self addMethodItem:  historyItem.
+	
+	self recorder enqueueEvent: (self recorder dictionaryForClassItem: historyItem announcement: anAnn)
 ]
 
 { #category : 'printing' }

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -178,7 +178,9 @@ CooSession >> addCompletionItem: aCompletionEntryItem [
 	item choices: aCompletionEntryItem entries.
 	item index: aCompletionEntryItem index. "Could be computed instead of storing it."
 	item selectedItem: aCompletionEntryItem selectedItem.
-	item fetchers: (aCompletionEntryItem entries collect: [ :each | each fetcher class name]).
+
+	item fetchers: (aCompletionEntryItem entries collect: [ :each | each fetcher ]).
+
 
 	completionItems addFirst: item.
 	
@@ -187,7 +189,7 @@ CooSession >> addCompletionItem: aCompletionEntryItem [
 	userSelectionHandler handleNewSelectionItem: item. 
 	
 	"pass the selected item to the recorder"
-	self recorder enqueueEvent: (self recorder dictionaryForClassItem: item announcement: CoCompletionItemSelected).
+	self recorder enqueueEvent: (self recorder dictionaryForCompletionItem: item announcement: CoCompletionItemSelected).
 ]
 
 { #category : 'method handling' }
@@ -215,7 +217,7 @@ CooSession >> addModifiedMethodInVocabulary: anAnn [
 	
 	self addMethodItem: item.
 	
-	self recorder enqueueEvent: (self recorder dictionaryForClassItem: item announcement: anAnn).
+	self recorder enqueueEvent: (self recorder dictionaryForMethodItem: item announcement: anAnn).
 ]
 
 { #category : 'navigation' }
@@ -257,7 +259,7 @@ CooSession >> addNewMethodInVocabulary: anAnn [
 	self addMethodItem: historyItem. "we could also decide that when a class gets a new method the name of the class is getting more important. 
 	Focus of attention. So this can be computed latter based on such information. "
 
-	self recorder enqueueEvent: (self recorder dictionaryForClassItem: historyItem announcement: anAnn )
+	self recorder enqueueEvent: (self recorder dictionaryForMethodItem: historyItem announcement: anAnn )
 ]
 
 { #category : 'low-level' }
@@ -465,7 +467,7 @@ CooSession >> removeMethodFromVocabulary: anAnn [
 
 	self addMethodItem:  historyItem.
 	
-	self recorder enqueueEvent: (self recorder dictionaryForClassItem: historyItem announcement: anAnn)
+	self recorder enqueueEvent: (self recorder dictionaryForMethodItem: historyItem announcement: anAnn)
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
Before,

Both `CooSession` and `CooHistoryEventRecorder` were subscribed to the system announcer. `CooHistoryEventRecorder` unsubscribed `CooSession` from the system announcer and reimplemented the same logic.

This PR fixes that by introducing a dependency from `CooSession` to `CooHistoryEventRecorder`. When an announcement is first intercepted (for example, by `addNewMethodInVocabulary:`), it is added to `methodDescriptions` and `ProgramEntityHandler` before being enqueued. At that point, the recorder is needed, which explains the new dependency.

This also allows us to use the information contained in `CooInteractionItem` and send it to the server. The new information we now have access to includes `fetchers` and `choices`.

To prevent a circular dependency, we removed the `session` instance variable from `CooHistoryEventRecorder`, since it is no longer needed. It was previously used to handle new events and selected items, but this responsibility now belongs to `CooSession`, making that dependency unnecessary.

Adding the new dependency, as explained above, also requires updating the baseline.
