### PR TITLE
New pipeline

### DIFF
--- a/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderMock.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderMock.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'CooHistoryEventRecorderMock',
+	#superclass : 'CooHistoryEventRecorder',
+	#category : 'ExtendedHeuristicCompletion-History-Recorder-Tests-Mocks',
+	#package : 'ExtendedHeuristicCompletion-History-Recorder-Tests',
+	#tag : 'Mocks'
+}
+
+{ #category : 'actions' }
+CooHistoryEventRecorderMock >> putBytes: bytes category: aCategory [
+	self error 
+]

--- a/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderTest.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderTest.class.st
@@ -21,10 +21,9 @@ CooHistoryEventRecorderTest >> setUp [
 
 	initialSubscriptionNumber := recorder announcer numberOfSubscriptions.
 
-	recorder logToTranscript: false.
 	recorder deliveryEnabled: false.
 	recorder deliveryBatchSize: 100.
-	recorder saveOnDisk: false.
+
 	recorder drainPendingEvents.
 	recorder instVarNamed: 'deliveryProcess' put: nil.
 ]
@@ -191,29 +190,25 @@ CooHistoryEventRecorderTest >> testIncludesInstanceOfReturnsTrueWhenPresent [
 ]
 
 { #category : 'tests' }
-CooHistoryEventRecorderTest >> testPrepareForImageSaveClearsPendingEventsWhenSaveOnDiskIsFalse [
+CooHistoryEventRecorderTest >> testPrepareForImageSaveWhenErrorShouldKeepEvents [
+ 
+	1 to: (recorder deliveryBatchSize) do: 
 
-	recorder saveOnDisk: false.
-	recorder enqueueEvent: (Dictionary new
+	[ :i | recorder enqueueEvent: (Dictionary new
 			 at: #kind put: #test;
-			 yourself).
-
+			 yourself).].
+	
 	recorder prepareForImageSave.
 
-	self assert: recorder pendingEvents isEmpty.
-]
-
-{ #category : 'tests' }
-CooHistoryEventRecorderTest >> testPrepareForImageSaveKeepsPendingEventsWhenSaveOnDiskIsTrue [
-
-	recorder saveOnDisk: true.
+	self assert: recorder pendingEvents size equals: 100.
+	
 	recorder enqueueEvent: (Dictionary new
 			 at: #kind put: #test;
-			 yourself).
-
+			 yourself). 
+	
 	recorder prepareForImageSave.
 
-	self assert: recorder pendingEvents size equals: 1.
+	self assert: recorder pendingEvents size equals: 101.
 ]
 
 { #category : 'tests' }

--- a/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderTest.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder-Tests/CooHistoryEventRecorderTest.class.st
@@ -5,8 +5,9 @@ Class {
 		'recorder',
 		'initialSubscriptionNumber'
 	],
-	#category : 'ExtendedHeuristicCompletion-History-Recorder-Tests',
-	#package : 'ExtendedHeuristicCompletion-History-Recorder-Tests'
+	#category : 'ExtendedHeuristicCompletion-History-Recorder-Tests-Core',
+	#package : 'ExtendedHeuristicCompletion-History-Recorder-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }
@@ -25,7 +26,6 @@ CooHistoryEventRecorderTest >> setUp [
 	recorder deliveryBatchSize: 100.
 
 	recorder drainPendingEvents.
-	recorder instVarNamed: 'deliveryProcess' put: nil.
 ]
 
 { #category : 'tests' }
@@ -192,6 +192,8 @@ CooHistoryEventRecorderTest >> testIncludesInstanceOfReturnsTrueWhenPresent [
 { #category : 'tests' }
 CooHistoryEventRecorderTest >> testPrepareForImageSaveWhenErrorShouldKeepEvents [
  
+	recorder := CooHistoryEventRecorderMock new. 
+	
 	1 to: (recorder deliveryBatchSize) do: 
 
 	[ :i | recorder enqueueEvent: (Dictionary new

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -723,7 +723,7 @@ CooHistoryEventRecorder >> prepareForImageSave [
 	self waitForDeliveryProcess.
 	self deliverNow.
 	lastDeliveryError 
-		ifNil: [ self clearPendingEvents. ].		
+		ifNil: [ self clearPendingEvents. ].
 
 	^ self
 ]

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -405,9 +405,9 @@ CooHistoryEventRecorder class >> shutDown: quitting [
 
 { #category : 'system startup' }
 CooHistoryEventRecorder class >> startUp: resuming [
-
+	resuming ifTrue:[
 	(uniqueInstance notNil and: [ uniqueInstance installed ])
-		ifTrue: [ uniqueInstance install ]
+		ifTrue: [ uniqueInstance install ]]
 ]
 
 { #category : 'accessing' }
@@ -722,7 +722,8 @@ CooHistoryEventRecorder >> prepareForImageSave [
 
 	self waitForDeliveryProcess.
 	self deliverNow.
-	self clearPendingEvents.
+	lastDeliveryError 
+		ifNil: [ self clearPendingEvents. ].		
 
 	^ self
 ]

--- a/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Recorder/CooHistoryEventRecorder.class.st
@@ -208,15 +208,12 @@ Class {
 		'deliveryProcess',
 		'lastDeliveryError',
 		'lastDeliveryResponse',
-		'logToTranscript',
-		'saveOnDisk',
 		'deliveryBatchSize'
 	],
 	#classInstVars : [
 		'uniqueInstance',
 		'defaultServerUrl',
 		'defaultCategory',
-		'defaultSaveOnDisk',
 		'defaultDeliveryBatchSize'
 	],
 	#category : 'ExtendedHeuristicCompletion-History-Recorder',
@@ -261,12 +258,6 @@ CooHistoryEventRecorder class >> defaultCategory [
 CooHistoryEventRecorder class >> defaultDeliveryBatchSize [
 
 	^ defaultDeliveryBatchSize ifNil: [ defaultDeliveryBatchSize := 100 ]
-]
-
-{ #category : 'cleanup' }
-CooHistoryEventRecorder class >> defaultSaveOnDisk [
-
-	^ defaultSaveOnDisk ifNil: [ defaultSaveOnDisk := false ]
 ]
 
 { #category : 'cleanup' }
@@ -394,19 +385,6 @@ CooHistoryEventRecorder class >> reset [
 ]
 
 { #category : 'accessing' }
-CooHistoryEventRecorder class >> saveOnDisk [
-
-	^ self uniqueInstance saveOnDisk
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder class >> saveOnDisk: aBoolean [
-
-	defaultSaveOnDisk := aBoolean.
-	self uniqueInstance saveOnDisk: aBoolean
-]
-
-{ #category : 'accessing' }
 CooHistoryEventRecorder class >> serverUrl [
 
 	^ self uniqueInstance serverUrl
@@ -489,13 +467,11 @@ CooHistoryEventRecorder >> deliverNow [
 	[
 		lastDeliveryResponse := self putBytes: bytes category: self category.
 		lastDeliveryError := nil.
-		self log: 'CooHistoryEventRecorder delivered ', events size printString, ' event(s).'
 	]
 		on: Error
 		do: [ :ex |
 			lastDeliveryError := ex.
-			self requeueEvents: events.
-			self log: 'CooHistoryEventRecorder delivery failed: ', ex description ].
+			self requeueEvents: events.].
 
 	^ lastDeliveryResponse
 ]
@@ -656,7 +632,6 @@ CooHistoryEventRecorder >> imageInfo [
 	info := Dictionary new.
 	info at: #imageVersion put: (self safeValue: [ SystemVersion current version asString ] ifError: [ nil ]).
 	info at: #latestUpdate put: (self safeValue: [ SystemVersion current commitHash asString ] ifError: [ nil ]).
-	info at: #imagePath put: (self safeValue: [ SmalltalkImage current imagePath asString ] ifError: [ nil ]).
 	info at: #imageHash put: (self safeValue: [ SmalltalkImage current imagePath hash ] ifError: [ nil ]).
 	info at: #sessionUUID put: (self safeValue: [ SmalltalkImage current session id asString ] ifError: [ nil ]).
 	info at: #sessionCreationTime put: (self safeValue: [ SmalltalkImage current session creationTime asString ] ifError: [ nil ]).
@@ -680,9 +655,7 @@ CooHistoryEventRecorder >> initialize [
 	pendingEvents := OrderedCollection new.
 	deliveryMutex := Mutex new.
 	installed := false.
-	saveOnDisk := self class defaultSaveOnDisk.
 	deliveryBatchSize := self class defaultDeliveryBatchSize.
-	logToTranscript := true
 ]
 
 { #category : 'actions' }
@@ -697,7 +670,7 @@ CooHistoryEventRecorder >> install [
 	
 
 	installed := true.
-	self log: 'CooHistoryEventRecorder installed. Server: ', self serverUrl asString.
+	
 
 	^ self
 ]
@@ -718,27 +691,6 @@ CooHistoryEventRecorder >> lastDeliveryError [
 CooHistoryEventRecorder >> lastDeliveryResponse [
 
 	^ lastDeliveryResponse
-]
-
-{ #category : 'logging' }
-CooHistoryEventRecorder >> log: aString [
-
-	logToTranscript ifFalse: [ ^ self ].
-	Transcript
-		show: aString;
-		cr
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder >> logToTranscript [
-
-	^ logToTranscript
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder >> logToTranscript: aBoolean [
-
-	logToTranscript := aBoolean
 ]
 
 { #category : 'actions' }
@@ -767,8 +719,6 @@ CooHistoryEventRecorder >> pendingEvents [
 
 { #category : 'system startup' }
 CooHistoryEventRecorder >> prepareForImageSave [
-
-	self saveOnDisk ifTrue: [ ^ self ].
 
 	self waitForDeliveryProcess.
 	self deliverNow.
@@ -807,8 +757,6 @@ CooHistoryEventRecorder >> putBytes: aByteArray category: aCategory [
 		enforceHttpSuccess: true;
 		entity: entity.
 
-	logToTranscript ifTrue: [ client logToTranscript ].
-
 	client put.
 
 	^ client response
@@ -828,18 +776,6 @@ CooHistoryEventRecorder >> safeValue: aBlock ifError: errorBlock [
 	^ [ aBlock value ]
 		  on: Error
 		  do: [ :ex | errorBlock value ]
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder >> saveOnDisk [
-
-	^ saveOnDisk ifNil: [ saveOnDisk := self class defaultSaveOnDisk ]
-]
-
-{ #category : 'accessing' }
-CooHistoryEventRecorder >> saveOnDisk: aBoolean [
-
-	saveOnDisk := aBoolean
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
in this PR we :
*  deleted `imagePath` variable
* deleted `logToTranscript` 
* deleted `saveOnDisk`
* better handling to quit and start Pharo image, the old implementation triggers `startup` each image save even when we are not quitting the image
* In `prepareForImageSave` if any error happens, we will `clearPendingEvents` no mater if the payload is sent successfuly or not, which can cause data loss. Now if any error occures we will have them back in our `pendingEvents`