### PR TITLE
the delta extraction was collecting every AST message selector.

### DIFF
--- a/src/ExtendedHeuristicCompletion-History-Benchmarks/CooStaticBenchmarksMessageHistory.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Benchmarks/CooStaticBenchmarksMessageHistory.class.st
@@ -20,7 +20,8 @@ CooStaticBenchmarksMessageHistory >> deltaMessageSelectors [
 
 	| entries |
 	entries := self session programEntityHandler selectorEntries ifNil: [ #(  ) ].
-	^ (entries flatCollect: [ :each | each deltaMessages ]) asSet
+	^ ((entries flatCollect: [ :each | each deltaMessages ])
+		   select: [ :each | self shouldBenchmarkMessageSelector: each ]) asSet
 ]
 
 { #category : 'running' }
@@ -40,7 +41,9 @@ CooStaticBenchmarksMessageHistory >> run [
 			scannedMethods := scannedMethods + 1.
 			method parseTree ifNotNil: [ :parseTree |
 					parseTree nodesDo: [ :node |
-							(node isMessage and: [ cachedSelectors includes: node selector ]) ifTrue: [
+							(node isMessage and: [
+								 (cachedSelectors includes: node selector) and: [
+									 self shouldBenchmarkMessageSelector: node selector ] ]) ifTrue: [
 									Transcript
 										cr;
 										show: '## Benched messages: ';
@@ -61,4 +64,11 @@ CooStaticBenchmarksMessageHistory >> session [
 CooStaticBenchmarksMessageHistory >> session: aSession [
 
 	session := aSession
+]
+
+{ #category : 'benchmarks' }
+CooStaticBenchmarksMessageHistory >> shouldBenchmarkMessageSelector: aSelector [
+
+	^ (CooMethodHistoryItem isMessageCompletionSelector: aSelector)
+		  and: [ aSelector asString size >= 2 ]
 ]

--- a/src/ExtendedHeuristicCompletion-History-Tests/CooHistoryItemTest.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Tests/CooHistoryItemTest.class.st
@@ -56,6 +56,40 @@ CooHistoryItemTest >> testMethodItemDefaultDeltaMessagesIsEmpty [
 ]
 
 { #category : 'tests' }
+CooHistoryItemTest >> testMessageCompletionSelectorRejectsPunctuation [
+
+	#( ',' '.' ';' '+' '->' '<=' ) do: [ :selector |
+		self deny:
+			(CooMethodHistoryItem isMessageCompletionSelector: selector) ]
+]
+
+{ #category : 'tests' }
+CooHistoryItemTest >> testMessageCompletionSelectorAcceptsUnaryAndKeywordSelectors [
+
+	self assert:
+		(CooMethodHistoryItem isMessageCompletionSelector: #yourself).
+	self assert:
+		(CooMethodHistoryItem isMessageCompletionSelector: #at:put:)
+]
+
+{ #category : 'tests' }
+CooHistoryItemTest >> testMessageCompletionSelectorsFromASTFiltersBinarySelectors [
+
+	| ast selectors |
+	ast := RBParser parseMethod:
+		       'sample | text |
+		       self alpha; beta: 1.
+		       text := ''a'' , ''b''.
+		       ^ 1 + 2'.
+	selectors := CooMethodHistoryItem messageCompletionSelectorsFromAST: ast.
+
+	self assert: (selectors includes: #alpha).
+	self assert: (selectors includes: #beta:).
+	self deny: (selectors includes: #,).
+	self deny: (selectors includes: #+)
+]
+
+{ #category : 'tests' }
 CooHistoryItemTest >> testMethodItemPrintOnShowsSelector [
 
 	| item |

--- a/src/ExtendedHeuristicCompletion-History-Tests/HistoryCachePopulatorTest.class.st
+++ b/src/ExtendedHeuristicCompletion-History-Tests/HistoryCachePopulatorTest.class.st
@@ -90,6 +90,25 @@ HistoryCachePopulatorTest >> testComputeDeltaMessageBetweenReturnsNewSelectors [
 ]
 
 { #category : 'running' }
+HistoryCachePopulatorTest >> testComputeDeltaMessageBetweenFiltersBinarySelectors [
+
+	| oldAst newAst deltaMessages |
+	oldAst := RBParser parseMethod: 'sample ^ self alpha'.
+	newAst := RBParser parseMethod:
+		          'sample | text |
+		          text := ''a'' , ''b''.
+		          self beta: text.
+		          ^ 1 + 2'.
+	deltaMessages := populator
+		                 computeDeltaMessageBetween: newAst
+		                 andOld: oldAst.
+
+	self assert: (deltaMessages includes: #beta:).
+	self deny: (deltaMessages includes: #,).
+	self deny: (deltaMessages includes: #+)
+]
+
+{ #category : 'running' }
 HistoryCachePopulatorTest >> testExtractMethodFromDiffNodeRejectsNonMethods [
 
 	| operation |

--- a/src/ExtendedHeuristicCompletion-History/CooMethodHistoryItem.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooMethodHistoryItem.class.st
@@ -15,6 +15,24 @@ Class {
 	#tag : 'StructuralModel'
 }
 
+{ #category : 'testing' }
+CooMethodHistoryItem class >> isMessageCompletionSelector: aSelector [
+
+	| selector |
+	aSelector ifNil: [ ^ false ].
+	selector := aSelector asSymbol.
+	^ selector isUnary or: [ selector isKeyword ]
+]
+
+{ #category : 'accessing' }
+CooMethodHistoryItem class >> messageCompletionSelectorsFromAST: aMethodAst [
+
+	aMethodAst ifNil: [ ^ #(  ) ].
+	^ ((aMethodAst allChildren select: [ :each | each isMessage ])
+		   collect: [ :each | each selector ])
+		  select: [ :each | self isMessageCompletionSelector: each ]
+]
+
 { #category : 'accessing' }
 CooMethodHistoryItem >> ast [
 	^ ast

--- a/src/ExtendedHeuristicCompletion-History/CooSession.class.st
+++ b/src/ExtendedHeuristicCompletion-History/CooSession.class.st
@@ -279,11 +279,9 @@ CooSession >> classEntries [
 { #category : 'helpers' }
 CooSession >> computeDeltaMessageBetween: aNewMethodAst andOld: anOldMethodAst [
 
-	^ ((aNewMethodAst allChildren select: [ :each | each isMessage ])
-			collect: [ :each | each selector ])
+	^ (CooMethodHistoryItem messageCompletionSelectorsFromAST: aNewMethodAst)
 		  difference:
-		  ((anOldMethodAst allChildren select: [ :each | each isMessage ]) 
-				collect: [ :each | each selector ])
+		  (CooMethodHistoryItem messageCompletionSelectorsFromAST: anOldMethodAst)
 ]
 
 { #category : 'helpers' }

--- a/src/ExtendedHeuristicCompletion-History/HistoryCachePopulator.class.st
+++ b/src/ExtendedHeuristicCompletion-History/HistoryCachePopulator.class.st
@@ -89,11 +89,9 @@ HistoryCachePopulator >> computeDeltaMessageBetween: aNewMethodAst andOld: anOld
 	but we should be able to indicate that an item is recreated from a git repo or
 	 based on the user interaction.
 	"
-	^ ((aNewMethodAst allChildren select: [ :each | each isMessage ])
-			collect: [ :each | each selector ])
+	^ (CooMethodHistoryItem messageCompletionSelectorsFromAST: aNewMethodAst)
 		  difference:
-		  ((anOldMethodAst allChildren select: [ :each | each isMessage ]) 
-				collect: [ :each | each selector ])
+		  (CooMethodHistoryItem messageCompletionSelectorsFromAST: anOldMethodAst)
 ]
 
 { #category : 'compute population' }
@@ -239,7 +237,7 @@ HistoryCachePopulator >> processMethodAddition: anAddition into: aCollection tim
 	selector ifNil: [ ^ self ].
 
 	ast := self tryParseAST: anAddition leftContents.
-	deltaMessage := ast allChildren select: [ :each | each isMessage ] thenCollect: [ :each | each selector ].
+	deltaMessage := CooMethodHistoryItem messageCompletionSelectorsFromAST: ast.
 
 
 	item := CooAddedMethodHistoryItem new
@@ -288,7 +286,7 @@ HistoryCachePopulator >> processMethodRemoval: aRemoval into: aCollection timest
 	selector ifNil: [ ^ self ].
 
 	ast := self tryParseAST: aRemoval rightContents.
-	deltaMessage := ast allChildren select: [ :each | each isMessage ] thenCollect: [ :each | each selector ].
+	deltaMessage := CooMethodHistoryItem messageCompletionSelectorsFromAST: ast.
 
 
 	item := CooRemovedMethodHistoryItem new


### PR DESCRIPTION
selectors like ,, +, ->, <= are valid binary selectors, but they are bad targets for this message-completion benchmark.
  I added a shared filter so only unary and keyword selectors are kept.